### PR TITLE
Ruleset: allow for T_FN token backfill

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -23,6 +23,7 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
     </rule>
 
 


### PR DESCRIPTION
PHP 7.4 introduced a new T_FN token which is backfilled by PHPCS since version 3.5.3, so PHPCS standards using the token are presumed to use PHPCS 3.5.3+.