### PR TITLE
Composer/ruleset: update for PHPCompatibility 10.0.0

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -24,6 +24,9 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
+        <exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
     </rule>
 
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.5.0",
-        "phpcompatibility/php-compatibility" : "^9.0.0",
+        "phpcompatibility/php-compatibility" : "^9.0.0 || ^10.0.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },
     "require-dev" : {


### PR DESCRIPTION
Already allow for PHPCompatibility 10.0.0 which is due in not too long.

For external standards which use this ruleset, always allow for the current major and the next major if in active development.
This prevents issues with Composer not being able to install on dev branches.

Includes some updates to the ruleset exclusions for new tokens being sniffed for in PHPCompatibility 10.0.0 (which are backfilled in PHPCS, so not a problem for PHPCS standards to use).