### PR TITLE
Composer/ruleset: allow for more PHP 8.0 token constants

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -26,6 +26,9 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
         <exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
     </rule>
 


### PR DESCRIPTION
PHP 8.0 will introduce yet more new token constants. A PR to sniff some more of those will be opened shortly in PHPCompatibility, so we should allow for these to be used in external PHPCS standards.

The token constants are expected to be backfilled by PHPCS as of version 3.5.7. The backfilling of the tokenization _using these tokens_ won't go into PHPCS until PHPCS 4.0.0.

See: squizlabs/PHP_CodeSniffer#3041