### PR TITLE
Ruleset: prevent sniff conflict

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -46,6 +46,10 @@
         <!-- Allow for the first condition of a multi-line control structure to be on the same line
              as the control structure keyword. -->
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
+
+        <!-- This standard enforces a blank line before each function, which conflicts with this
+             PHPCS 3.6.2+ PSR12 sniff when a function is the first content of a class. -->
+        <exclude name="PSR12.Classes.OpeningBraceSpace.Found"/>
     </rule>
 
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.5.0",
+        "squizlabs/php_codesniffer" : "^3.6.2",
         "phpcompatibility/php-compatibility" : "^9.0.0 || ^10.0.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },


### PR DESCRIPTION
Ruleset: prevent sniff conflict

PHPCS 3.6.2 introduced a new sniff to the PSR12 standard, which enforces no blank line at the start of a class.

That sniff conflicts with the `Squiz.WhiteSpace.FunctionSpacing` sniff when the `spacingBeforeFirst` property is set to `1`.

As the property setting predates the new sniff, excluding the new sniff will prevent a lot of unnecessary code churn in repos using this standard.

This does, however, require raising the minimum PHPCS version to PHPCS 3.6.2 as otherwise a "sniff not found" error could be displayed.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.2