### PR TITLE
README: update for Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Installation
 
 Run the following from the root of your project:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev phpcsstandards/phpcsdevcs:"^1.0"
 ```
 
@@ -39,6 +40,7 @@ composer require --dev phpcsstandards/phpcsdevcs:"^1.0"
 
 If you work on several different sniff repos, you may want to install this toolset globally:
 ```bash
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer global require --dev phpcsstandards/phpcsdevcs:"^1.0"
 ```
 


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for PHPCSDevCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution