### PR TITLE
Composer/ruleset: allow for PHP 8.1 token constants

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -29,6 +29,8 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_enumFound"/>
         <exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
     </rule>
 


### PR DESCRIPTION
PHP 8.1 will introduce yet more new token constants. Detection for `T_READONLY` is already in PHPCompatibility 10.0, `T_ENUM` will follow shortly.

As PHPCS polyfills these tokens, we should allow for these constants to be used in external PHPCS standards.

The token constants are expected to be backfilled by PHPCS as of version 3.7.0.