### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name" : "phpcsstandards/phpcsdevcs",
     "description" : "Sane ruleset for the code in external standards for PHP_CodeSniffer.",
     "type" : "phpcodesniffer-standard",
-    "keywords" : [ "phpcs", "php_codesniffer", "phpcodesniffer-standard" ],
+    "keywords" : [ "phpcs", "static analysis", "php_codesniffer", "phpcodesniffer-standard" ],
     "license" : "LGPL-3.0-or-later",
     "authors" : [
         {


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.