### PR TITLE
Ruleset: configure PSR12.ControlStructures.BooleanOperatorPlacement sniff

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -81,6 +81,13 @@
     ####################################################################
     -->
 
+    <!-- PSR12 doesn't enforce consistency in where boolean operators are placed. We do. -->
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">
+        <properties>
+            <property name="allowOnly" value="first"/>
+        </properties>
+    </rule>
+
     <!-- PSR12 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>


### PR DESCRIPTION
Set the `allowOnly` property for the `PSR12.ControlStructures.BooleanOperatorPlacement` sniff to "first" to enforce boolean operators to always be at the start of a line, not the end.


This property is available since PHPCS 3.5.4.