### PR TITLE
GH Actions: add workflow to label PRs which are in a conflict state

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,27 @@
+name: Check PRs for merge conflicts
+
+on:
+  # Check for new conflicts due to merges.
+  push:
+    branches:
+      - main
+  # Check conflicts in new PRs and for resolved conflicts due to an open PR being updated.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  check-prs:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards'
+
+    name: Check PRs for merge conflicts
+
+    steps:
+      - name: Check PRs for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "Status: has merge conflict"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
_For consistency with the other repos in the organisation._

This commit adds a new workflow which automatically checks for merge conflicts in open PRs.

The selected action runner also has an option to post a comment when a conflict is detected as well as when the conflict has been resolved. While not currently used, this feature might be useful in the future.

Refs:
* https://github.com/eps1lon/actions-label-merge-conflict