### PR TITLE
Ruleset: update schema URL

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDev" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDev" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>A PSR-12 based standard for use by sniff developers to check the code style of external PHPCS standards</description>
 


### PR DESCRIPTION
PHPCS now offers permalinks for the schema.

Refs:
* PHPCSStandards/PHP_CodeSniffer 1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com