### PR TITLE
Composer: update minimum PHPCS version to 3.13.0

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -119,6 +119,9 @@
     <!-- No spacing on the inside of arbitrary parentheses. -->
     <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
 
+    <!-- No spacing inside heredoc/nowdocs identifiers. -->
+    <rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing"/>
+
     <!-- Align the equal operator in assignment blocks. -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
@@ -225,6 +228,9 @@
     <!-- Efficiency: don't unnecessarily use double quotes. -->
     <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 
+    <!-- Efficiency: don't unnecessarily use heredocs. -->
+    <rule ref="Generic.Strings.UnnecessaryHeredoc"/>
+
     <!-- Error prevention: warns when an inner loop uses the same incrementor as the outer loop. -->
     <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
 
@@ -232,6 +238,9 @@
     <rule ref="Generic.CodeAnalysis.AssignmentInCondition">
         <exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
     </rule>
+
+    <!-- Error prevention: use parentheses when mixing boolean operators. -->
+    <rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
 
     <!-- Clean up: remove redundant code. -->
     <rule ref="Squiz.PHP.NonExecutableCode">

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ PHPCSDev ruleset for sniff repos
 
 Once this project is installed, you will see a new `PHPCSDev` ruleset in the list of installed standards when you run `phpcs -i`.
 
-**Important: This ruleset currently requires PHP_CodeSniffer >= `3.6.2+`.**
+**Important: This ruleset currently requires PHP_CodeSniffer >= `3.13.0+`.**
 
 > As sniffs developers will mostly work with the latest version of PHP_CodeSniffer, this shouldn't cause any problems.
 >

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.6.2",
+        "squizlabs/php_codesniffer" : "^3.13.0",
         "phpcompatibility/php-compatibility" : "^9.0.0 || ^10.0.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },


### PR DESCRIPTION
... to allow for taking advantage of a few new sniffs.