### PR TITLE
Composer/ruleset: allow for (some) PHP 8.4 token constants

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -31,6 +31,9 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_enumFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_public_setFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_protected_setFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_private_setFound"/>
         <exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
     </rule>
 


### PR DESCRIPTION
PHP 8.4 introduced a few new token constants related to asymmetric visibility. Detection for these new tokens is already in PHPCompatibility 10.0.

As PHPCS polyfills these tokens, we should allow for these to be used in external PHPCS standards.

The token constants are backfilled by PHPCS as of version 3.13.0.

Refs:
* PHPCSStandards/PHP_CodeSniffer#871
* PHPCompatibility/PHPCompatibility#1809