### PR TITLE
Ruleset: allow for PHP 8.0 token constant

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -24,6 +24,7 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_attributeFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>


### PR DESCRIPTION
PHP 8.0 introduced the `T_ATTRIBUTE` token, which wasn't accounted for yet in this ruleset.

Detection for `T_ATTRIBUTE` is already in PHPCompatibility 10.0.

As PHPCS polyfills the token, we should allow for it to be used in external PHPCS standards.