### PR TITLE
Composer/Ruleset: require PHPCSExtra 1.5.0 and add extra sniffs

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -237,6 +237,12 @@
     <rule ref="Universal.UseStatements.DisallowUseConst"/>
     <rule ref="Universal.UseStatements.DisallowUseFunction"/>
 
+    <!-- Require parentheses for exit/die. -->
+    <rule ref="Universal.PHP.RequireExitDieParentheses"/>
+
+    <!-- Require no spaces around the ellipses for first class callables. -->
+    <rule ref="Universal.WhiteSpace.FirstClassCallableSpacing"/>
+
 
     <!--
     ####################################################################
@@ -273,6 +279,18 @@
     <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
         <severity>0</severity>
     </rule>
+
+
+    <!--
+    ####################################################################
+    Code style: Attributes.
+
+    These rules are eventually expected to be included in PERCS.
+    ####################################################################
+    -->
+
+    <rule ref="Universal.Attributes.BracketSpacing"/>
+    <rule ref="Universal.Attributes.DisallowAttributeParentheses"/>
 
 
     <!--

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.3 || ^4.0.0",
+        "squizlabs/php_codesniffer" : "^3.13.5 || ^4.0.1",
         "phpcompatibility/php-compatibility" : "^10.0.0@dev",
-        "phpcsstandards/phpcsextra" : "^1.4.2"
+        "phpcsstandards/phpcsextra" : "^1.5.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
The PHPCSExtra 1.5.0 release adds seven new sniffs, four of which are likely to be included in PERCS at a later point in time. So, it makes sense to already enforce these rules for the packages using this standard.

Ref:
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.5.0